### PR TITLE
Update main.py

### DIFF
--- a/TypingPro/main.py
+++ b/TypingPro/main.py
@@ -80,3 +80,10 @@ while gameOn:
     pygame.display.update()
         
 pygame.quit()
+# End
+# <-- LICENCE info -->
+'''
+TypingPro
+Copyright Ved Rathi
+Licensed under MIT (https://github.com/Ved-Programmer/TypingPro/blob/master/LICENSE)
+'''


### PR DESCRIPTION
Adding the LICENCE links to the screen

As I said open source is open source, meant to be copied,

I was just exploring repositories on github and then I have found that many repositories do like this in their code..
![Screenshot 2021-01-22 204917](https://user-images.githubusercontent.com/65970997/105509356-6b2f4380-5cf3-11eb-92d5-143827ad158f.png)

Notice what happened ? the licence information is included in the code, so even if some one copies you code he can't restrict the rules of licence, and then the information of the licence lies over there, usually in the top or the bottom of the script,

I could have kept it in the top of the python script but the import statements should always be on top, it is a pyflakes/python grammar.

Hope this PR help you.

---

Regards, 
Navdeep